### PR TITLE
Refactor outdated pom.xml version to avoid leaked vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
         <spring.version>4.0.6.RELEASE</spring.version>
         <spring-security.version>3.2.5.RELEASE</spring-security.version>
         <selenium.version>2.42.2</selenium.version>
-        <jackson.version>2.3.2</jackson.version>
+        <jackson.version>2.8.11.1</jackson.version>
         <joda.version>2.2</joda.version>
         <postgresql.version>9.3-1101-jdbc41</postgresql.version>
         <jooq.version>3.5.3</jooq.version>
@@ -406,7 +406,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.3.5</version>
+                <version>4.3.6</version>
             </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>


### PR DESCRIPTION
This feature add the following:
- Refactor pom.xml to fix vulnerabilities warnings

```xml
<dependency>
                <groupId>org.apache.httpcomponents</groupId>
                <artifactId>httpclient</artifactId>
                <version>4.3.6</version>
</dependency>
```

```xml
<jackson.version>2.8.11.1</jackson.version>
```
